### PR TITLE
Fill out tests + expand injection capabilities

### DIFF
--- a/src/injection.d.ts
+++ b/src/injection.d.ts
@@ -13,24 +13,28 @@ export interface StaticInjection extends BaseEvaluableInjection {
 export interface CreatableInjection<Specifier> extends BaseEvaluableInjection {
   type: 'creatable';
   source: Specifier;
+  constructorArgs?: Injection<Specifier>[];
 }
 
 export interface PropertyInjection<Specifier> extends BaseEvaluableInjection {
   type: 'property';
   source: Specifier;
   property: string;
+  constructorArgs?: Injection<Specifier>[];
 }
 
 export interface MethodInjection<Specifier> extends BaseEvaluableInjection {
   type: 'method';
   source: Specifier;
   method: string;
-  args: Injection<Specifier>[];
+  constructorArgs?: Injection<Specifier>[];
+  args?: Injection<Specifier>[];
 }
 
 export interface InvocableInjection<Specifier> extends BaseEvaluableInjection {
   type: 'invocable';
   source: Specifier;
+  args?: Injection<Specifier>[];
 }
 
 export interface DictionaryInjection<Specifier> extends BaseEvaluableInjection {

--- a/test/container-test.ts
+++ b/test/container-test.ts
@@ -1,0 +1,335 @@
+import {
+  Container,
+  Factory,
+  FactoryRegistry,
+  SpecifierResolver,
+  Initializer,
+  Destructor,
+  CreatableInjection,
+  StaticInjection,
+  Invocable,
+  InvocableRegistry,
+  MethodInjection
+} from '../src/index';
+import {
+  SimpleSpecifier,
+  SimpleSpecifierResolver
+} from './test-helpers';
+
+const { module, test } = QUnit;
+
+class Foo {
+  id: number;
+  className: string;
+
+  constructor(id: number) {
+    this.id = id;
+    this.className = 'Foo';
+  }
+
+  sayHello(name: string) {
+    return `hello ${name}!`;
+  }
+}
+
+class Bar {
+
+}
+
+const fooFactory: Factory<Foo> = {
+  create(id: number): Foo {
+    return new Foo(id);
+  }
+}
+
+const initializeOwner: Initializer<Foo> = {
+  name: 'initializeOwner',
+  initialize(foo: Foo) {
+    foo['owner'] = '123';
+  }
+}
+
+const callInit: Initializer<Foo> = {
+  name: 'callInit',
+  initialize(foo: Foo) {
+    foo['init']();
+  }
+}
+
+const teardownOwner: Destructor<Foo> = {
+  name: 'teardownOwner',
+  teardown(foo: Foo) {
+    delete foo['owner'];
+  }
+}
+
+const callDestroy: Destructor<Foo> = {
+  name: 'callDestroy',
+  teardown(foo: Foo) {
+    foo['destroy']();
+  }
+}
+
+const generateID: Invocable = {
+  invoke(): number {
+    this._id = this._id || 0;
+    return ++this._id;
+  }
+};
+
+const add: Invocable = {
+  invoke(...args: number[]): number {
+    return args.reduce((prev: number, current: number) => { return prev + current; }, 0);
+  }
+}
+
+module('Container');
+
+test('can invoke registered invocables', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(null, invocableRegistry);
+
+  invocableRegistry.registerInvocable('add', add);
+  let result = container.invoke('add');
+
+  assert.strictEqual(result, 0, 'add has been called with no arguments');
+});
+
+test('can invoke registered invocables with custom arguments', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(null, invocableRegistry);
+
+  invocableRegistry.registerInvocable('add', add);
+  let result = container.invoke('add', [1, 2, 3]);
+
+  assert.strictEqual(result, 6, 'add has been called with custom arguments');
+});
+
+test('can look up instances based on registered factories', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let container = new Container(factoryRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+  let instance = container.lookup('foo');
+
+  assert.ok(instance instanceof Foo);
+  assert.strictEqual(instance.id, undefined);
+});
+
+test('can look up instances and pass registered constructor arguments', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+  invocableRegistry.registerInvocable('generateId', generateID);
+  factoryRegistry.registerConstructorArguments('foo', [{
+    type: 'invocable',
+    source: 'generateId'
+  }]);
+  let instance = container.lookup('foo');
+
+  assert.ok(instance instanceof Foo);
+  assert.ok(instance.id > 0);
+});
+
+test('can look up instances and pass custom constructor arguments', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+  let instance = container.lookup('foo', [123]);
+
+  assert.ok(instance instanceof Foo);
+  assert.equal(instance.id, 123);
+});
+
+module('Container#evaluateInjection')
+
+test('can evaluate static injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  let result = container.evaluateInjection({
+    type: 'static',
+    value: 'abc'
+  });
+
+  assert.equal(result, 'abc');
+});
+
+test('can evaluate creatable injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+
+  let result = container.evaluateInjection({
+    type: 'creatable',
+    source: 'foo'
+  });
+
+  assert.ok(result instanceof Foo);
+});
+
+test('can evaluate property injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+
+  let result = container.evaluateInjection({
+    type: 'method',
+    source: 'foo',
+    method: 'sayHello',
+    args: ['rwjblue']
+  });
+
+  assert.equal(result, 'hello rwjblue!');
+});
+
+test('can evaluate method injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+
+  let result = container.evaluateInjection({
+    type: 'method',
+    source: 'foo',
+    method: 'sayHello',
+    args: [{ type: 'static', value: 'rwjblue' }]
+  });
+
+  assert.equal(result, 'hello rwjblue!');
+});
+
+test('can evaluate invocable injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  invocableRegistry.registerInvocable('add', add);
+
+  let result = container.evaluateInjection({
+    type: 'invocable',
+    source: 'add'
+  });
+
+  assert.strictEqual(result, 0, 'add has been called with no arguments');
+
+  invocableRegistry.registerInvocableArguments('add', [1, 2]);
+
+  result = container.evaluateInjection({
+    type: 'invocable',
+    source: 'add'
+  });
+
+  assert.strictEqual(result, 3, 'add has been called with registered arguments');
+
+  result = container.evaluateInjection({
+    type: 'invocable',
+    source: 'add',
+    args: [5, { type: 'static', value: 99 }]
+  });
+
+  assert.strictEqual(result, 104, 'add has been called with injected arguments');
+});
+
+test('can evaluate dictionary injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+
+  let result = container.evaluateInjection(
+    {
+      type: 'dictionary',
+      value: {
+        user: 'rwjblue',
+        greeting: {
+          type: 'method',
+          source: 'foo',
+          method: 'sayHello',
+          args: [{ type: 'static', value: 'rwjblue' }]
+        } as MethodInjection<SimpleSpecifier>
+      }
+    }
+  );
+
+  assert.deepEqual(result, { user: 'rwjblue', greeting: 'hello rwjblue!' });
+});
+
+test('can evaluate object injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+
+  let result = container.evaluateInjection(
+    {
+      type: 'object',
+      keys: [
+        'user',
+        {
+          type: 'static',
+          value: 'greeting'
+        }
+      ],
+      values: [
+        'rwjblue',
+        {
+          type: 'method',
+          source: 'foo',
+          method: 'sayHello',
+          args: [{ type: 'static', value: 'rwjblue' }]
+        } as MethodInjection<SimpleSpecifier>
+      ]
+    }
+  );
+
+  assert.deepEqual(result, { user: 'rwjblue', greeting: 'hello rwjblue!' });
+});
+
+test('can evaluate array injections', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let factoryRegistry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let invocableRegistry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let container = new Container(factoryRegistry, invocableRegistry);
+
+  factoryRegistry.registerFactory('foo', fooFactory);
+
+  let result = container.evaluateInjection(
+    {
+      type: 'array',
+      values: [
+        'one',
+        {
+          type: 'static',
+          value: 'two'
+        }
+      ]
+    }
+  );
+
+  assert.deepEqual(result, ['one', 'two']);
+});

--- a/test/factory-registry-test.ts
+++ b/test/factory-registry-test.ts
@@ -7,32 +7,12 @@ import {
   CreatableInjection,
   StaticInjection
 } from '../src/index';
+import {
+  SimpleSpecifier,
+  SimpleSpecifierResolver
+} from './test-helpers';
 
 const { module, test } = QUnit;
-
-declare type SimpleSpecifier = string;
-
-class SimpleSpecifierResolver implements SpecifierResolver<SimpleSpecifier> {
-  specifierKey(specifier: string): string {
-    return specifier;
-  }
-
-  specifierFromKey(key: string): string {
-    return key;
-  }
-
-  specifierEquals(specifier: string, target: string): boolean {
-    return specifier === target;
-  }
-
-  specifierMatches(specifier: string, target: string): boolean {
-    return specifier === target;
-  }
-
-  matchingSpecifiers(specifier: string): string[] {
-    return [specifier, '*'];
-  }
-}
 
 class Foo {
 

--- a/test/factory-registry-test.ts
+++ b/test/factory-registry-test.ts
@@ -3,7 +3,9 @@ import {
   FactoryRegistry,
   SpecifierResolver,
   Initializer,
-  Destructor
+  Destructor,
+  CreatableInjection,
+  StaticInjection
 } from '../src/index';
 
 const { module, test } = QUnit;
@@ -139,4 +141,139 @@ test('destructors can be registered and resolved with a priority', function(asse
   registry.registerDestructor('*', callDestroy);
   registry.registerDestructor('foo', teardownOwnerNew);
   assert.deepEqual(registry.destructorsFor('foo'), [teardownOwnerNew, callDestroy]);
+});
+
+test('constructor args can be registered, unregistered, and resolved', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let injections = [{
+    type: 'creatable',
+    source: 'bar'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '123'
+  } as StaticInjection];
+
+  registry.registerConstructorArguments('foo', injections);
+  assert.strictEqual(registry.constructorArgumentsFor('foo'), injections);
+
+  registry.unregisterConstructorArguments('foo');
+  assert.strictEqual(registry.constructorArgumentsFor('foo'), undefined);
+});
+
+test('constructor args can be registered and resolved with priority', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let injections = [{
+    type: 'creatable',
+    source: 'bar'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '123'
+  } as StaticInjection];
+  let injections2 = [{
+    type: 'creatable',
+    source: 'foo'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '234'
+  } as StaticInjection];
+
+  registry.registerConstructorArguments('*', injections);
+  assert.strictEqual(registry.constructorArgumentsFor('foo'), injections);
+
+  registry.registerConstructorArguments('foo', injections2);
+  assert.strictEqual(registry.constructorArgumentsFor('foo'), injections2);
+});
+
+test('initializer args can be registered, unregistered, and resolved', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let injections = [{
+    type: 'creatable',
+    source: 'bar'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '123'
+  } as StaticInjection];
+
+  registry.registerInitializerArguments('foo', 'initOwner', injections);
+  assert.strictEqual(registry.initializerArgumentsFor('foo', 'initOwner'), injections);
+  registry.unregisterInitializerArguments('foo');
+  assert.strictEqual(registry.initializerArgumentsFor('foo', 'initOwner'), undefined);
+
+  registry.registerInitializerArguments('foo', 'initOwner', injections);
+  assert.strictEqual(registry.initializerArgumentsFor('foo', 'initOwner'), injections);
+  registry.unregisterInitializerArguments('foo', 'initOwner');
+  assert.strictEqual(registry.initializerArgumentsFor('foo', 'initOwner'), undefined);
+});
+
+test('initializer args can be registered and resolved with priority', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let injections = [{
+    type: 'creatable',
+    source: 'bar'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '123'
+  } as StaticInjection];
+  let injections2 = [{
+    type: 'creatable',
+    source: 'foo'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '234'
+  } as StaticInjection];
+
+  registry.registerInitializerArguments('*', 'initOwner', injections);
+  assert.strictEqual(registry.initializerArgumentsFor('foo', 'initOwner'), injections);
+  registry.registerInitializerArguments('foo', 'initOwner', injections2);
+  assert.strictEqual(registry.initializerArgumentsFor('foo', 'initOwner'), injections2);
+});
+
+test('destructor args can be registered, unregistered, and resolved', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let injections = [{
+    type: 'creatable',
+    source: 'bar'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '123'
+  } as StaticInjection];
+
+  registry.registerDestructorArguments('foo', 'teardownFoo', injections);
+  assert.strictEqual(registry.destructorArgumentsFor('foo', 'teardownFoo'), injections);
+  registry.unregisterDestructorArguments('foo');
+  assert.strictEqual(registry.destructorArgumentsFor('foo', 'teardownFoo'), undefined);
+
+  registry.registerDestructorArguments('foo', 'teardownFoo', injections);
+  assert.strictEqual(registry.destructorArgumentsFor('foo', 'teardownFoo'), injections);
+  registry.unregisterDestructorArguments('foo', 'teardownFoo');
+  assert.strictEqual(registry.destructorArgumentsFor('foo', 'teardownFoo'), undefined);
+});
+
+test('destructor args can be registered and resolved with priority', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new FactoryRegistry<SimpleSpecifier, Foo>(specifierResolver);
+  let injections = [{
+    type: 'creatable',
+    source: 'bar'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '123'
+  } as StaticInjection];
+  let injections2 = [{
+    type: 'creatable',
+    source: 'foo'
+  } as CreatableInjection<SimpleSpecifier>, {
+    type: 'static',
+    value: '234'
+  } as StaticInjection];
+
+  registry.registerDestructorArguments('*', 'teardownFoo', injections);
+  assert.strictEqual(registry.destructorArgumentsFor('foo', 'teardownFoo'), injections);
+  registry.registerDestructorArguments('foo', 'teardownFoo', injections2);
+  assert.strictEqual(registry.destructorArgumentsFor('foo', 'teardownFoo'), injections2);
 });

--- a/test/invocable-registry-test.ts
+++ b/test/invocable-registry-test.ts
@@ -1,0 +1,92 @@
+import {
+  Invocable,
+  InvocableRegistry,
+  CreatableInjection,
+  StaticInjection
+} from '../src/index';
+import {
+  SimpleSpecifier,
+  SimpleSpecifierResolver
+} from './test-helpers';
+
+const { module, test } = QUnit;
+
+const doSomething: Invocable = {
+  invoke(...thingsToDo: string[]) {
+    return 'Things to do: ' + thingsToDo.join(',');
+  }
+};
+
+const doSomethingOnce: Invocable = {
+  invoke() {
+    this._result = "This is the only time I'm doing something";
+    return this.result;
+  },
+
+  get result() {
+    return this._result;
+  }
+}
+
+module('InvocableRegistry');
+
+test('invocables can be registered, unregistered, and resolved', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+
+  registry.registerInvocable('doSomething', doSomething);
+  assert.strictEqual(registry.invocableFor('doSomething'), doSomething);
+
+  registry.unregisterInvocable('doSomething');
+  assert.strictEqual(registry.invocableFor('doSomething'), undefined);
+});
+
+test('invocables can be registered and resolved with a priority', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+
+  registry.registerInvocable('*', doSomething);
+  assert.strictEqual(registry.invocableFor('doSomething'), doSomething);
+
+  registry.registerInvocable('doSomething', doSomethingOnce);
+  assert.strictEqual(registry.invocableFor('doSomething'), doSomethingOnce);
+
+  registry.unregisterInvocable('doSomething');
+  assert.strictEqual(registry.invocableFor('doSomething'), doSomething);
+});
+
+test('invocable args can be registered, unregistered, and resolved', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let injections = [
+    'write todo list', {
+    type: 'static',
+    value: 'dishes'
+  } as StaticInjection];
+
+  registry.registerInvocableArguments('doSomething', injections);
+  assert.strictEqual(registry.invocableArgumentsFor('doSomething'), injections);
+
+  registry.unregisterInvocableArguments('doSomething');
+  assert.strictEqual(registry.invocableArgumentsFor('doSomething'), undefined);
+});
+
+test('invocable args can be registered and resolved with priority', function(assert) {
+  let specifierResolver = new SimpleSpecifierResolver;
+  let registry = new InvocableRegistry<SimpleSpecifier>(specifierResolver);
+  let injections = [
+    'write todo list', {
+    type: 'static',
+    value: 'dishes'
+  } as StaticInjection];
+  let injections2 = [
+    'water plants',
+    'change world'];
+
+  registry.registerInvocableArguments('*', injections);
+  assert.strictEqual(registry.invocableArgumentsFor('doSomething'), injections);
+
+  registry.registerInvocableArguments('doSomething', injections2);
+  assert.strictEqual(registry.invocableArgumentsFor('doSomething'), injections2);
+});
+

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,0 +1,27 @@
+import {
+  SpecifierResolver
+} from '../src/index';
+
+export type SimpleSpecifier = string;
+
+export class SimpleSpecifierResolver implements SpecifierResolver<SimpleSpecifier> {
+  specifierKey(specifier: string): string {
+    return specifier;
+  }
+
+  specifierFromKey(key: string): string {
+    return key;
+  }
+
+  specifierEquals(specifier: string, target: string): boolean {
+    return specifier === target;
+  }
+
+  specifierMatches(specifier: string, target: string): boolean {
+    return specifier === target;
+  }
+
+  matchingSpecifiers(specifier: string): string[] {
+    return [specifier, '*'];
+  }
+}


### PR DESCRIPTION
* Fills out unit tests for `FactoryRegistry`, `InvocableRegistry`, and `Container`.
* Fixes `invoke` in `Container`
* Expands injections to allow for custom constructor and invocation args when referencing creatables and invocables.
